### PR TITLE
Remove unnecessary markdown code fences from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-````markdown
 # The Courrier 📰
 
 > **WebApp de veille technologique pour les mods Nexus Mods**
@@ -549,4 +548,3 @@ Voir [LICENSE](./LICENSE) pour plus de détails.
 - [Vercel](https://vercel.com) - Plateforme de déploiement
 - [Netlify](https://netlify.com) - Plateforme de déploiement
 
-````


### PR DESCRIPTION
Cleaned up the README by deleting extraneous markdown code fences at the beginning and end of the file.