### PR TITLE
fix: isolate session cache per user + add search/batch/export features

### DIFF
--- a/api/nexus/tracked.mjs
+++ b/api/nexus/tracked.mjs
@@ -1,8 +1,6 @@
 
 import fetch from "node-fetch";
-import { readFileSync } from "fs";
-import path from "path";
-import { fileURLToPath } from "url";
+import { toEpoch, getCategoryName, withPool, sortVersionsSemantic } from "../utils/NexusUtils.mjs";
 
 const CACHE = new Map();
 const TTL = {
@@ -11,8 +9,8 @@ const TTL = {
   game: 24 * 60 * 60_000, // 24h pour les infos de jeux
 };
 const now = () => Date.now();
-const kTracked = "tracked";
-const kMod = (domain, id) => `mod:${domain}:${id}`;
+const kTracked = (username) => `tracked:${username}`;
+const kMod = (username, domain, id) => `mod:${username}:${domain}:${id}`;
 const kGame = (domain) => `game:${domain}`;
 
 const cacheGet = (k) => {
@@ -51,45 +49,6 @@ async function fetchJson(url, { headers }) {
   }
 }
 
-const toEpoch = (v) => {
-  if (!v) return 0;
-  if (typeof v === "number") return v;
-  if (typeof v === "string") {
-    const n = Number(v);
-    if (!Number.isNaN(n) && n > 0) return n;
-    const d = Date.parse(v);
-    if (!Number.isNaN(d)) return Math.floor(d / 1000);
-  }
-  return 0;
-};
-
-// Import des catégories depuis le fichier JSON centralisé
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const categoriesPath = path.join(__dirname, '..', '..', 'src', 'data', 'nexus-categories.json');
-const CATEGORIES_BY_GAME = JSON.parse(readFileSync(categoriesPath, 'utf-8'));
-
-// Récupère le nom d'une catégorie par son ID et le jeu
-function getCategoryName(domain, categoryId) {
-  if (!categoryId) return null;
-  const gameCategories = CATEGORIES_BY_GAME[domain];
-  if (!gameCategories) return null;
-  return gameCategories[categoryId] || null;
-}
-
-async function withPool(items, limit, fn) {
-  const ret = [];
-  let i = 0;
-  const workers = Array(Math.min(limit, items.length))
-    .fill(0)
-    .map(async () => {
-      while (i < items.length) {
-        const idx = i++;
-        ret[idx] = await fn(items[idx], idx);
-      }
-    });
-  await Promise.all(workers);
-  return ret;
-}
 
 async function getGameInfo(domain, username, apiKey) {
   const ck = kGame(domain);
@@ -138,7 +97,7 @@ export default async function handler(req, res) {
     return res.status(401).json({ error: "Missing Nexus API credentials. Please configure your username and API key." });
   }
 
-  const hit = cacheGet(kTracked);
+  const hit = cacheGet(kTracked(username));
   if (hit) {
     return res.status(200).json(hit);
   }
@@ -174,7 +133,7 @@ export default async function handler(req, res) {
     }).filter((m) => m.id && m.domain);
 
     const enriched = await withPool(rows, 4, async (m) => {
-      const ck = kMod(m.domain, m.id);
+      const ck = kMod(username, m.domain, m.id);
       const modCache = cacheGet(ck);
       if (modCache) return { ...m, ...modCache };
 
@@ -192,17 +151,7 @@ export default async function handler(req, res) {
             { headers: nexusHeaders(username, apiKey) }
           );
           if (changelogData && typeof changelogData === 'object') {
-            // Tri sémantique des versions (1.13 > 1.12 > 1.9)
-            const versions = Object.keys(changelogData).sort((a, b) => {
-              const aParts = a.split('.').map(Number);
-              const bParts = b.split('.').map(Number);
-              for (let i = 0; i < Math.max(aParts.length, bParts.length); i++) {
-                const aNum = aParts[i] || 0;
-                const bNum = bParts[i] || 0;
-                if (aNum !== bNum) return bNum - aNum;
-              }
-              return 0;
-            });
+            const versions = sortVersionsSemantic(Object.keys(changelogData));
             
             changelog = versions.slice(0, 3).map(version => ({
               version,
@@ -278,7 +227,7 @@ export default async function handler(req, res) {
       };
     });
 
-    cacheSet(kTracked, enrichedWithGames, TTL.tracked);
+    cacheSet(kTracked(username), enrichedWithGames, TTL.tracked);
 
     return res.status(200).json(enrichedWithGames);
   } catch (error) {

--- a/api/utils/NexusUtils.mjs
+++ b/api/utils/NexusUtils.mjs
@@ -1,0 +1,54 @@
+import { readFileSync } from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const categoriesPath = path.join(__dirname, "..", "..", "src", "data", "nexus-categories.json");
+const CATEGORIES_BY_GAME = JSON.parse(readFileSync(categoriesPath, "utf-8"));
+
+export const toEpoch = (v) => {
+  if (!v) return 0;
+  if (typeof v === "number") return v;
+  if (typeof v === "string") {
+    const n = Number(v);
+    if (!Number.isNaN(n) && n > 0) return n;
+    const d = Date.parse(v);
+    if (!Number.isNaN(d)) return Math.floor(d / 1000);
+  }
+  return 0;
+};
+
+export function getCategoryName(domain, categoryId) {
+  if (!categoryId) return null;
+  const gameCategories = CATEGORIES_BY_GAME[domain];
+  if (!gameCategories) return null;
+  return gameCategories[categoryId] || null;
+}
+
+export async function withPool(items, limit, fn) {
+  const ret = [];
+  let i = 0;
+  const workers = Array(Math.min(limit, items.length))
+    .fill(0)
+    .map(async () => {
+      while (i < items.length) {
+        const idx = i++;
+        ret[idx] = await fn(items[idx], idx);
+      }
+    });
+  await Promise.all(workers);
+  return ret;
+}
+
+export function sortVersionsSemantic(versions) {
+  return [...versions].sort((a, b) => {
+    const aParts = a.split(".").map(Number);
+    const bParts = b.split(".").map(Number);
+    for (let i = 0; i < Math.max(aParts.length, bParts.length); i++) {
+      const aNum = aParts[i] || 0;
+      const bNum = bParts[i] || 0;
+      if (aNum !== bNum) return bNum - aNum;
+    }
+    return 0;
+  });
+}

--- a/server.mjs
+++ b/server.mjs
@@ -5,7 +5,7 @@ import cors from "cors";
 import dotenv from "dotenv";
 import path from "path";
 import { fileURLToPath } from "url";
-import { readFileSync } from "fs";
+import { toEpoch, getCategoryName, withPool, sortVersionsSemantic } from "./api/utils/NexusUtils.mjs";
 
 dotenv.config();
 
@@ -80,45 +80,6 @@ async function fetchJson(url, { headers }) {
   }
 }
 
-const toEpoch = (v) => {
-  if (!v) return 0;
-  if (typeof v === "number") return v;
-  if (typeof v === "string") {
-    const n = Number(v);
-    if (!Number.isNaN(n) && n > 0) return n;
-    const d = Date.parse(v);
-    if (!Number.isNaN(d)) return Math.floor(d / 1000);
-  }
-  return 0;
-};
-
-// Import des catégories depuis le fichier JSON centralisé
-// Pour ajouter un nouveau jeu, voir ADDING_GAME_CATEGORIES.md
-const categoriesPath = path.join(__dirname, 'src', 'data', 'nexus-categories.json');
-const CATEGORIES_BY_GAME = JSON.parse(readFileSync(categoriesPath, 'utf-8'));
-
-// Récupère le nom d'une catégorie par son ID et le jeu
-function getCategoryName(domain, categoryId) {
-  if (!categoryId) return null;
-  const gameCategories = CATEGORIES_BY_GAME[domain];
-  if (!gameCategories) return null;
-  return gameCategories[categoryId] || null;
-}
-
-async function withPool(items, limit, fn) {
-  const ret = [];
-  let i = 0;
-  const workers = Array(Math.min(limit, items.length))
-    .fill(0)
-    .map(async () => {
-      while (i < items.length) {
-        const idx = i++;
-        ret[idx] = await fn(items[idx], idx);
-      }
-    });
-  await Promise.all(workers);
-  return ret;
-}
 
 async function getGameInfo(domain, username, apiKey) {
   const ck = kGame(domain);
@@ -253,17 +214,7 @@ app.get("/api/nexus/tracked", async (req, res) => {
           );
 
           if (changelogData && typeof changelogData === 'object') {
-            // Tri sémantique des versions (1.13 > 1.12 > 1.9)
-            const versions = Object.keys(changelogData).sort((a, b) => {
-              const aParts = a.split('.').map(Number);
-              const bParts = b.split('.').map(Number);
-              for (let i = 0; i < Math.max(aParts.length, bParts.length); i++) {
-                const aNum = aParts[i] || 0;
-                const bNum = bParts[i] || 0;
-                if (aNum !== bNum) return bNum - aNum;
-              }
-              return 0;
-            });
+            const versions = sortVersionsSemantic(Object.keys(changelogData));
             
             changelog = versions.slice(0, 3).map(version => ({
               version,
@@ -278,8 +229,7 @@ app.get("/api/nexus/tracked", async (req, res) => {
 
         }
 
-        // Récupérer le nom de la catégorie (système dynamique + fallback statique)
-        const categoryName = await getCategoryName(m.domain, details.category_id);
+        const categoryName = getCategoryName(m.domain, details.category_id);
 
         const merged = {
           name: m.name || details.name || details.title,

--- a/src/pages/ActuUpdatePage.jsx
+++ b/src/pages/ActuUpdatePage.jsx
@@ -10,6 +10,7 @@ export default function ActuUpdatePage({ credentials, getSteamInfo }) {
   const [period, setPeriod] = useState(7);
   const [selectedGame, setSelectedGame] = useState("ALL");
   const [sortBy, setSortBy] = useState("date");
+  const [searchQuery, setSearchQuery] = useState("");
 
   useEffect(() => {
     // Marquer comme visité après 2 secondes
@@ -25,23 +26,31 @@ export default function ActuUpdatePage({ credentials, getSteamInfo }) {
       const key = g.domain || g.gameId || g.name;
       return key === selectedGame;
     });
-    
+
+
     for (const g of gamesToShow) {
       const key = g.domain || g.gameId || g.name;
       let mods = modsForGame(key).filter(
         (m) => Number(m.updatedAt || 0) >= cutoff
       );
-      
-      // Tri des mods selon l'option sélectionnée
+
+      if (searchQuery.trim()) {
+        const q = searchQuery.toLowerCase();
+        mods = mods.filter(
+          (m) =>
+            (m.name || "").toLowerCase().includes(q) ||
+            (m.author || "").toLowerCase().includes(q)
+        );
+      }
+
       if (sortBy === "name") {
         mods.sort((a, b) => (a.name || "").localeCompare(b.name || ""));
       } else if (sortBy === "author") {
         mods.sort((a, b) => (a.author || "").localeCompare(b.author || ""));
       } else {
-        // Par défaut : tri par date (plus récent en premier)
         mods.sort((a, b) => Number(b.updatedAt || 0) - Number(a.updatedAt || 0));
       }
-      
+
       if (mods.length) {
         out.push({
           gameLabel: g.name || g.domain || `Game ${g.gameId || ""}`.trim(),
@@ -55,7 +64,7 @@ export default function ActuUpdatePage({ credentials, getSteamInfo }) {
         Number(b.mods[0]?.updatedAt || 0) - Number(a.mods[0]?.updatedAt || 0)
     );
     return out;
-  }, [games, modsForGame, cutoff, selectedGame, sortBy]);
+  }, [games, modsForGame, cutoff, selectedGame, sortBy, searchQuery]);
 
   const periodLabel = () => {
     if (period === 7) return "7 derniers jours";
@@ -143,6 +152,22 @@ export default function ActuUpdatePage({ credentials, getSteamInfo }) {
           Rafraîchir
         </button>
       </div>
+
+      <div className="mb-4">
+        <input
+          type="text"
+          className="pico-select w-full"
+          placeholder="🔍 Rechercher par nom ou auteur..."
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+        />
+      </div>
+
+      {searchQuery && (
+        <p className="text-sm text-slate-500 dark:text-slate-400 mb-4">
+          {grouped.reduce((acc, g) => acc + g.mods.length, 0)} résultat{grouped.reduce((acc, g) => acc + g.mods.length, 0) !== 1 ? "s" : ""} pour « {searchQuery} »
+        </p>
+      )}
 
       <div className="mb-6 flex flex-col md:flex-row gap-4">
         <div className="flex-1 max-w-md">

--- a/src/pages/NexusModsPage.jsx
+++ b/src/pages/NexusModsPage.jsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, useEffect } from "react";
+import { useMemo, useState, useEffect, useCallback } from "react";
 import useNexusMods from "../components/useNexusMods";
 import useLastVisit from "../components/useLastVisit";
 import EnhancedChangelog from "../components/EnhancedChangelog";
@@ -10,9 +10,11 @@ export default function NexusModsPage({ credentials, getSteamInfo }) {
   const [gameKey, setGameKey] = useState("ALL");
   const [untracking, setUntracking] = useState(null);
   const [sortBy, setSortBy] = useState("date");
+  const [searchQuery, setSearchQuery] = useState("");
+  const [selectedMods, setSelectedMods] = useState(new Set());
+  const [batchUntracking, setBatchUntracking] = useState(false);
 
   useEffect(() => {
-    // Marquer comme visité après 2 secondes
     const timer = setTimeout(() => updateLastVisit(), 2000);
     return () => clearTimeout(timer);
   }, [updateLastVisit]);
@@ -20,7 +22,6 @@ export default function NexusModsPage({ credentials, getSteamInfo }) {
   const mods = useMemo(() => {
     let result = [];
     if (!gameKey || gameKey === "ALL") {
-      // Afficher tous les mods de tous les jeux
       for (const g of games) {
         const key = g.domain || g.gameId || g.name;
         result.push(...modsForGame(key));
@@ -28,32 +29,87 @@ export default function NexusModsPage({ credentials, getSteamInfo }) {
     } else {
       result = modsForGame(gameKey);
     }
-    
-    // Tri des mods
+
     if (sortBy === "name") {
       result.sort((a, b) => (a.name || "").localeCompare(b.name || ""));
     } else if (sortBy === "author") {
       result.sort((a, b) => (a.author || "").localeCompare(b.author || ""));
     } else {
-      // Par défaut : tri par date (plus récent en premier)
       result.sort((a, b) => Number(b.updatedAt || 0) - Number(a.updatedAt || 0));
     }
-    
+
+    if (searchQuery.trim()) {
+      const q = searchQuery.toLowerCase();
+      result = result.filter(
+        (m) =>
+          (m.name || "").toLowerCase().includes(q) ||
+          (m.author || "").toLowerCase().includes(q)
+      );
+    }
+
     return result;
-  }, [gameKey, modsForGame, games, sortBy]);
+  }, [gameKey, modsForGame, games, sortBy, searchQuery]);
 
   const handleUntrack = async (domain, modId, modName) => {
     if (!window.confirm(`Voulez-vous vraiment retirer "${modName}" de votre liste de mods suivis ?`)) {
       return;
     }
-    
     setUntracking(modId);
     const result = await untrackMod(domain, modId);
     setUntracking(null);
-    
     if (!result.success) {
       alert(`Erreur lors de la suppression : ${result.error}`);
     }
+  };
+
+  const toggleSelect = useCallback((domain, modId) => {
+    const key = `${domain}:${modId}`;
+    setSelectedMods((prev) => {
+      const next = new Set(prev);
+      next.has(key) ? next.delete(key) : next.add(key);
+      return next;
+    });
+  }, []);
+
+  const toggleSelectAll = () => {
+    if (selectedMods.size === mods.length) {
+      setSelectedMods(new Set());
+    } else {
+      setSelectedMods(new Set(mods.map((m) => `${m.domain}:${m.id}`)));
+    }
+  };
+
+  const handleBatchUntrack = async () => {
+    if (!window.confirm(`Retirer ${selectedMods.size} mod(s) de votre liste de suivi ?`)) return;
+    setBatchUntracking(true);
+    for (const key of selectedMods) {
+      const [domain, modId] = key.split(":");
+      await untrackMod(domain, modId);
+    }
+    setSelectedMods(new Set());
+    setBatchUntracking(false);
+  };
+
+  const handleExport = () => {
+    const allMods = games.flatMap((g) => modsForGame(g.domain || g.gameId || g.name));
+    const data = allMods.map((m) => ({
+      name: m.name,
+      author: m.author,
+      version: m.version,
+      category: m.category || null,
+      url: m.url,
+      game: m.gameName || m.domain,
+      updatedAt: m.updatedAt
+        ? new Date(Number(m.updatedAt) * (String(m.updatedAt).length > 10 ? 1 : 1000)).toISOString()
+        : null,
+    }));
+    const blob = new Blob([JSON.stringify(data, null, 2)], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `the-courrier-mods-${new Date().toISOString().split("T")[0]}.json`;
+    a.click();
+    URL.revokeObjectURL(url);
   };
 
   if (loading) {
@@ -63,7 +119,7 @@ export default function NexusModsPage({ credentials, getSteamInfo }) {
       </div>
     );
   }
-  
+
   if (error) {
     if (error.includes("credentials") || error.includes("401")) {
       return (
@@ -92,7 +148,7 @@ export default function NexusModsPage({ credentials, getSteamInfo }) {
       </div>
     );
   }
-  
+
   if (!games.length) {
     return (
       <div className="container mx-auto px-4 py-8 text-center">
@@ -102,11 +158,31 @@ export default function NexusModsPage({ credentials, getSteamInfo }) {
   }
 
   return (
-    <div className="container mx-auto px-4 py-8">
-      <h2 className="text-3xl font-bold text-slate-800 dark:text-white mb-6">
-        Liste des Mods
-      </h2>
-      
+    <div className="container mx-auto px-4 py-8 pb-24">
+      <div className="flex items-center justify-between mb-6 gap-4">
+        <h2 className="text-3xl font-bold text-slate-800 dark:text-white">
+          Liste des Mods
+        </h2>
+        <button
+          className="pico-btn-outline text-sm"
+          onClick={handleExport}
+          title="Exporter la liste complète en JSON"
+        >
+          ⬇️ Exporter JSON
+        </button>
+      </div>
+
+      {/* Barre de recherche */}
+      <div className="mb-4">
+        <input
+          type="text"
+          className="pico-select w-full"
+          placeholder="🔍 Rechercher par nom ou auteur..."
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+        />
+      </div>
+
       <div className="flex flex-col md:flex-row md:items-end md:justify-between mb-6 gap-4">
         <div className="flex-1 max-w-md">
           <label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">
@@ -144,7 +220,6 @@ export default function NexusModsPage({ credentials, getSteamInfo }) {
         </button>
       </div>
 
-      {/* Afficher les infos Steam du jeu sélectionné */}
       {gameKey && gameKey !== "ALL" && getSteamInfo && (() => {
         const selectedGame = games.find(g => (g.domain || g.gameId || g.name) === gameKey);
         const steamInfo = selectedGame ? getSteamInfo(selectedGame.domain) : null;
@@ -155,98 +230,155 @@ export default function NexusModsPage({ credentials, getSteamInfo }) {
         ) : null;
       })()}
 
+      {searchQuery && (
+        <p className="text-sm text-slate-500 dark:text-slate-400 mb-4">
+          {mods.length} résultat{mods.length !== 1 ? "s" : ""} pour « {searchQuery} »
+        </p>
+      )}
+
       {mods.length > 0 && (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          {mods.map((m) => (
-            <div className="pico-card flex flex-col" key={`${m.domain}-${m.id}`}>
-              {m.picture && (
-                <img src={m.picture} alt={m.name} className="w-full h-40 object-cover flex-shrink-0" />
-              )}
-              <div className="p-5 flex flex-col flex-grow">
-                <div className="flex items-start gap-2 mb-2">
-                  <h5 className="text-xl font-bold text-slate-800 dark:text-white flex-1">
-                    {m.name || `${m.domain}/${m.id}`}
-                  </h5>
-                  {isNew(m.updatedAt) && (
-                    <span className="px-2 py-1 bg-blue-500 text-white text-xs font-bold rounded-full">🆕 NEW</span>
-                  )}
-                </div>
+          {mods.map((m) => {
+            const selKey = `${m.domain}:${m.id}`;
+            const isSelected = selectedMods.has(selKey);
+            return (
+              <div
+                className={`pico-card flex flex-col transition-all ${isSelected ? "ring-2 ring-pico-primary" : ""}`}
+                key={`${m.domain}-${m.id}`}
+              >
+                <label className="flex items-center gap-2 px-3 pt-3 cursor-pointer select-none">
+                  <input
+                    type="checkbox"
+                    checked={isSelected}
+                    onChange={() => toggleSelect(m.domain, m.id)}
+                    className="w-4 h-4 accent-pico-primary"
+                  />
+                  <span className="text-xs text-slate-500 dark:text-slate-400">Sélectionner</span>
+                </label>
 
-                {m.summary && (
-                  <p className="text-sm text-slate-600 dark:text-slate-400 mb-3">{m.summary}</p>
+                {m.picture && (
+                  <img src={m.picture} alt={m.name} className="w-full h-40 object-cover flex-shrink-0" />
                 )}
+                <div className="p-5 flex flex-col flex-grow">
+                  <div className="flex items-start gap-2 mb-2">
+                    <h5 className="text-xl font-bold text-slate-800 dark:text-white flex-1">
+                      {m.name || `${m.domain}/${m.id}`}
+                    </h5>
+                    {isNew(m.updatedAt) && (
+                      <span className="px-2 py-1 bg-blue-500 text-white text-xs font-bold rounded-full">🆕 NEW</span>
+                    )}
+                  </div>
 
-                {m.category && (
-                  <div className="mb-3">
-                    <span className="px-2 py-1 bg-purple-100 dark:bg-purple-900/30 text-purple-700 dark:text-purple-300 rounded text-xs font-medium">
-                      📚 {m.category}
+                  {m.summary && (
+                    <p className="text-sm text-slate-600 dark:text-slate-400 mb-3">{m.summary}</p>
+                  )}
+
+                  {m.category && (
+                    <div className="mb-3">
+                      <span className="px-2 py-1 bg-purple-100 dark:bg-purple-900/30 text-purple-700 dark:text-purple-300 rounded text-xs font-medium">
+                        📚 {m.category}
+                      </span>
+                    </div>
+                  )}
+
+                  <div className="mb-3 flex items-center gap-2 flex-wrap">
+                    {m.previousVersion && m.previousVersion !== m.version && (
+                      <span className="px-2 py-1 bg-slate-200 dark:bg-slate-700 text-slate-600 dark:text-slate-400 rounded text-sm line-through">
+                        {m.previousVersion}
+                      </span>
+                    )}
+                    <span className="px-2 py-1 bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-300 rounded text-sm font-medium">
+                      Version {m.version || "?"}
+                    </span>
+                    <span className="text-sm text-slate-600 dark:text-slate-400">
+                      · par{" "}
+                      {m.author ? (
+                        <a
+                          href={`https://next.nexusmods.com/profile/${encodeURIComponent(m.author)}${m.gameId ? `?gameId=${m.gameId}` : ""}`}
+                          target="_blank"
+                          rel="noreferrer"
+                          className="text-pico-primary hover:underline"
+                        >
+                          {m.author}
+                        </a>
+                      ) : (
+                        "Auteur inconnu"
+                      )}
                     </span>
                   </div>
-                )}
 
-                <div className="mb-3 flex items-center gap-2 flex-wrap">
-                  {m.previousVersion && m.previousVersion !== m.version && (
-                    <span className="px-2 py-1 bg-slate-200 dark:bg-slate-700 text-slate-600 dark:text-slate-400 rounded text-sm line-through">
-                      {m.previousVersion}
-                    </span>
-                  )}
-                  <span className="px-2 py-1 bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-300 rounded text-sm font-medium">
-                    Version {m.version || "?"}
-                  </span>
-                  <span className="text-sm text-slate-600 dark:text-slate-400">
-                    · par{" "}
-                    {m.author ? (
+                  <EnhancedChangelog mod={m} maxLines={6} />
+
+                  <div className="mt-auto space-y-2">
+                    <div className="flex justify-between items-center">
                       <a
-                        href={`https://next.nexusmods.com/profile/${encodeURIComponent(m.author)}${m.gameId ? `?gameId=${m.gameId}` : ''}`}
+                        href={m.url}
                         target="_blank"
                         rel="noreferrer"
-                        className="text-pico-primary hover:underline"
+                        className={`pico-btn-primary text-sm ${m.url ? "" : "opacity-50 pointer-events-none"}`}
                       >
-                        {m.author}
+                        Ouvrir sur Nexus
                       </a>
-                    ) : (
-                      "Auteur inconnu"
-                    )}
-                  </span>
-                </div>
-
-                <EnhancedChangelog mod={m} maxLines={6} />
-
-                <div className="mt-auto space-y-2">
-                  <div className="flex justify-between items-center">
-                    <a
-                      href={m.url}
-                      target="_blank"
-                      rel="noreferrer"
-                      className={`pico-btn-primary text-sm ${m.url ? "" : "opacity-50 pointer-events-none"}`}
+                      <span className="px-2 py-1 bg-slate-100 dark:bg-slate-700 text-slate-700 dark:text-slate-300 rounded text-xs">
+                        {m.updatedAt
+                          ? new Date(
+                              Number(m.updatedAt) *
+                              (String(m.updatedAt).length > 10 ? 1 : 1000)
+                            ).toLocaleString()
+                          : "?"}
+                      </span>
+                    </div>
+                    <button
+                      className="w-full px-4 py-2 rounded-lg bg-red-500 hover:bg-red-600 text-white transition-colors text-sm font-medium disabled:opacity-50"
+                      onClick={() => handleUntrack(m.domain, m.id, m.name)}
+                      disabled={untracking === m.id}
                     >
-                      Ouvrir sur Nexus
-                    </a>
-                    <span className="px-2 py-1 bg-slate-100 dark:bg-slate-700 text-slate-700 dark:text-slate-300 rounded text-xs">
-                      {m.updatedAt
-                        ? new Date(
-                            Number(m.updatedAt) *
-                            (String(m.updatedAt).length > 10 ? 1 : 1000)
-                          ).toLocaleString()
-                        : "?"}
-                    </span>
+                      {untracking === m.id ? "Suppression..." : "🗑️ Ne plus suivre"}
+                    </button>
                   </div>
-                  <button
-                    className="w-full px-4 py-2 rounded-lg bg-red-500 hover:bg-red-600 text-white transition-colors text-sm font-medium disabled:opacity-50"
-                    onClick={() => handleUntrack(m.domain, m.id, m.name)}
-                    disabled={untracking === m.id}
-                  >
-                    {untracking === m.id ? "Suppression..." : "🗑️ Ne plus suivre"}
-                  </button>
                 </div>
               </div>
-            </div>
-          ))}
+            );
+          })}
           {!mods.length && (
             <p className="text-slate-500 dark:text-slate-400 col-span-full">
               Aucun mod pour ce jeu.
             </p>
           )}
+        </div>
+      )}
+
+      {/* Barre d'actions batch sticky */}
+      {selectedMods.size > 0 && (
+        <div className="fixed bottom-0 left-0 right-0 z-50 bg-white dark:bg-slate-800 border-t border-slate-200 dark:border-slate-700 shadow-lg px-4 py-3">
+          <div className="container mx-auto flex items-center justify-between gap-4 flex-wrap">
+            <div className="flex items-center gap-3">
+              <span className="font-medium text-slate-700 dark:text-slate-300">
+                {selectedMods.size} mod{selectedMods.size > 1 ? "s" : ""} sélectionné{selectedMods.size > 1 ? "s" : ""}
+              </span>
+              <button
+                className="text-sm text-pico-primary hover:underline"
+                onClick={toggleSelectAll}
+              >
+                {selectedMods.size === mods.length ? "Tout désélectionner" : "Tout sélectionner"}
+              </button>
+            </div>
+            <div className="flex gap-2">
+              <button
+                className="pico-btn-outline text-sm"
+                onClick={() => setSelectedMods(new Set())}
+              >
+                Annuler
+              </button>
+              <button
+                className="px-4 py-2 rounded-lg bg-red-500 hover:bg-red-600 text-white text-sm font-medium disabled:opacity-50"
+                onClick={handleBatchUntrack}
+                disabled={batchUntracking}
+              >
+                {batchUntracking ? "Suppression..." : `🗑️ Retirer la sélection (${selectedMods.size})`}
+              </button>
+            </div>
+          </div>
         </div>
       )}
     </div>


### PR DESCRIPTION
- Fix critical session leak (Bug #9): cache keys in api/nexus/tracked.mjs now include username — concurrent users no longer share tracked mod lists
- Extract shared utilities (toEpoch, getCategoryName, withPool, sortVersionsSemantic) to api/utils/NexusUtils.mjs; both server.mjs and tracked.mjs now import from it
- NexusModsPage: add search by name/author, batch untrack with sticky action bar, and JSON export button
- ActuUpdatePage: add search by name/author with result count